### PR TITLE
Enhanced reseeding of PRNGs

### DIFF
--- a/execute.c
+++ b/execute.c
@@ -1355,6 +1355,11 @@ static void suhosin_gen_entropy(php_uint32 *seedbuf TSRMLS_DC)
 #endif
 
     suhosin_SHA256Init(&context);
+
+    if (SUHOSIN_G(rands_seedkey) != NULL && *SUHOSIN_G(rands_seedkey) != 0) {
+        suhosin_SHA256Update(&context, (unsigned char*)SUHOSIN_G(rands_seedkey), strlen(SUHOSIN_G(rands_seedkey)));
+    }
+
 	suhosin_SHA256Update(&context, (void *) seedbuf, sizeof(php_uint32) * 8);
 	suhosin_SHA256Final((void *)seedbuf, &context);
 }
@@ -1432,11 +1437,7 @@ static int ih_srand(IH_HANDLER_PARAMS)
     int argc = ZEND_NUM_ARGS();
 	long seed;
 
-	if (zend_parse_parameters(argc TSRMLS_CC, "|l", &seed) == FAILURE || SUHOSIN_G(srand_ignore)) {
-    	return (1);
-    }
-
-    if (argc == 0) {
+    if (argc == 0 || zend_parse_parameters(argc TSRMLS_CC, "|l", &seed) == FAILURE || SUHOSIN_G(srand_ignore)) {
         suhosin_srand_auto(TSRMLS_C);
     } else {
         suhosin_srand(seed TSRMLS_CC);
@@ -1449,11 +1450,7 @@ static int ih_mt_srand(IH_HANDLER_PARAMS)
     int argc = ZEND_NUM_ARGS();
 	long seed;
 
-	if (zend_parse_parameters(argc TSRMLS_CC, "|l", &seed) == FAILURE || SUHOSIN_G(mt_srand_ignore)) {
-    	return (1);
-    }
-    
-    if (argc == 0) {
+    if (argc == 0 || zend_parse_parameters(argc TSRMLS_CC, "|l", &seed) == FAILURE || SUHOSIN_G(mt_srand_ignore)) {
         suhosin_mt_srand_auto(TSRMLS_C);
     } else {
         suhosin_mt_srand(seed TSRMLS_CC);

--- a/php_suhosin.h
+++ b/php_suhosin.h
@@ -235,6 +235,7 @@ ZEND_BEGIN_MODULE_GLOBALS(suhosin)
 	int          r_left;
     zend_bool    srand_ignore;
     zend_bool    mt_srand_ignore;
+	char*	rands_seedkey;
 	php_uint32   mt_state[625];
 	php_uint32   *mt_next;
 	int          mt_left;

--- a/suhosin.c
+++ b/suhosin.c
@@ -1021,6 +1021,7 @@ PHP_INI_BEGIN()
 
 	STD_ZEND_INI_BOOLEAN("suhosin.srand.ignore", "1", ZEND_INI_SYSTEM|ZEND_INI_PERDIR, OnUpdateMiscBool, srand_ignore,zend_suhosin_globals,	suhosin_globals)
 	STD_ZEND_INI_BOOLEAN("suhosin.mt_srand.ignore", "1", ZEND_INI_SYSTEM|ZEND_INI_PERDIR, OnUpdateMiscBool, mt_srand_ignore,zend_suhosin_globals,	suhosin_globals)
+	STD_PHP_INI_ENTRY("suhosin.rands.seedkey", "", PHP_INI_ALL, OnUpdateString, rands_seedkey, zend_suhosin_globals, suhosin_globals)
 
 PHP_INI_END()
 /* }}} */
@@ -1239,6 +1240,9 @@ PHP_RSHUTDOWN_FUNCTION(suhosin)
 	
 	SUHOSIN_G(abort_request) = 0;
 	
+	SUHOSIN_G(r_is_seeded) = 0;
+	SUHOSIN_G(mt_is_seeded) = 0;
+
 	if (SUHOSIN_G(decrypted_cookie)) {
 		efree(SUHOSIN_G(decrypted_cookie));
 		SUHOSIN_G(decrypted_cookie)=NULL;
@@ -1301,6 +1305,9 @@ PHP_MINFO_FUNCTION(suhosin)
 		if (zend_hash_find(EG(ini_directives), "suhosin.session.cryptkey", sizeof("suhosin.session.cryptkey"), (void **) &i)==SUCCESS) {
             i->displayer = suhosin_ini_displayer;
         }
+		if (zend_hash_find(EG(ini_directives), "suhosin.rands.seedkey", sizeof("suhosin.rands.seedkey"), (void **) &i)==SUCCESS) {
+            i->displayer = suhosin_ini_displayer;
+        }
     }
     
 	DISPLAY_INI_ENTRIES();
@@ -1312,6 +1319,9 @@ PHP_MINFO_FUNCTION(suhosin)
             i->displayer = NULL;
         }
 		if (zend_hash_find(EG(ini_directives), "suhosin.session.cryptkey", sizeof("suhosin.session.cryptkey"), (void **) &i)==SUCCESS) {
+            i->displayer = NULL;
+        }
+		if (zend_hash_find(EG(ini_directives), "suhosin.rands.seedkey", sizeof("suhosin.rands.seedkey"), (void **) &i)==SUCCESS) {
             i->displayer = NULL;
         }
     }


### PR DESCRIPTION
Often pseudo-random number generation in PHP applications is used for creation of sensitive material (application session IDs, API keys etc.). Suhosin already makes _mt_rand()_ and _rand()_ PRNGs much more secure by using 256-bit cryptographically hashed seed with customized Mersenne twister initialization.

This commit takes a step further by reseeding PRNGs with pseudo-random data on per-request basis and when corresponding functions are called (ignoring any supplied seed). This commit also introduces additional configurable key that can be used on low-entropy systems to impede predicting of 256-bit cryptographically hashed seed.

This commit makes the following changes:
1. When _suhosin.mt_srand.ignore_ and/or _suhosin.srand.ignore_ are enabled,
corresponding PRNGs are reseeded with random values (ignoring supplied
seeds) when _mt_srand($seed)_ and/or _srand($seed)_ are called. This way
applications that reseed PRNG(s) to create a brand new sequence of
random numbers will create a brand new sequence, but (in most cases)
with much more random/secure seed. Previous behavior was to ignore calls
to _mt_srand()_ and _srand()_ when _suhosin.mt_srand.ignore_ and/or
_suhosin.srand.ignore are enabled_.
2. _mt_rand()_ and _rand()_ PRNGs are reseeded before first use in each new
request. This way it is much harder to predict random numbers generated
in past (or subsequest) requests that are server by the same PHP
process. Previous behaviour was to automatically seed PRNGs before first
use in each new PHP process.
3. A new php.ini value _suhosin.rands.seedkey_ is introduced. This (along
with collected entropy) is cryptographically hashed and used as random
seeds for PRNGs. Setting this key to a long random and secret string
makes it even harder to predict generation of random PRNG seeds. This is
especially useful on systems without _/dev/urandom_.
