### PR TITLE
Documentation seems divert from suhosin.c

### DIFF
--- a/suhosin.ini
+++ b/suhosin.ini
@@ -224,7 +224,7 @@ suhosin.mail.protect = 1
 ; Flag that decides if the transparent session encryption key depends on the
 ; User-Agent field. (When activated this feature transparently adds a little
 ; bit protection against session fixation/hijacking attacks)
-;suhosin.session.cryptua = On
+;suhosin.session.cryptua = Off
 
 ; Flag that decides if the transparent session encryption key depends on the
 ; Documentroot field.


### PR DESCRIPTION
Looking into suhosin.c, it seems that "suhosin.session.cryptua" defaults to ´Off´:

$ grep suhosin.session.cryptua suhosin.c
    STD_ZEND_INI_BOOLEAN("suhosin.session.cryptua",     "0",        ZEND_INI_PERDIR|ZEND_INI_SYSTEM,    OnUpdateBool, session_cryptua,  zend_suhosin_globals,   suhosin_globals)

While http://suhosin.org/stories/configuration.html#suhosin-session-cryptua says ´On´.

I'm wrong?!? With kind regards, Jan. 
