### PR TITLE
introduced suhosin.log.use-x-request-id

### DIFF
--- a/log.c
+++ b/log.c
@@ -110,6 +110,7 @@ PHP_SUHOSIN_API void suhosin_log(int loglevel, char *fmt, ...)
 	char buf[5000] = {0};
 	char error[5000] = {0};
 	char *ip_address;
+	char *request_id;
 	char *fname;
 	char *alertstring;
 	int lineno = 0;
@@ -139,6 +140,18 @@ PHP_SUHOSIN_API void suhosin_log(int loglevel, char *fmt, ...)
 		ip_address = suhosin_getenv("REMOTE_ADDR", 11 TSRMLS_CC);
 		if (ip_address == NULL) {
 			ip_address = "REMOTE_ADDR not set";
+		}
+	}
+
+	if (SUHOSIN_G(log_use_x_request_id)) {
+		request_id = suhosin_getenv("HTTP_X_REQUEST_ID", 40 TSRMLS_CC);
+		if (request_id == NULL) {
+			request_id = "X-REQUEST-ID not set";
+		}
+	} else {
+		ip_address = suhosin_getenv("UNIQUE_ID", 40 TSRMLS_CC);
+		if (request_id == NULL) {
+			request_id = "UNIQUE_ID not set";
 		}
 	}
 	
@@ -177,13 +190,13 @@ PHP_SUHOSIN_API void suhosin_log(int loglevel, char *fmt, ...)
 			lineno = zend_get_executed_lineno(TSRMLS_C);
 			fname = (char *)zend_get_executed_filename(TSRMLS_C);
 		}
-		ap_php_snprintf(buf, sizeof(buf), "%s - %s (attacker '%s', file '%s', line %u)", alertstring, error, ip_address, fname, lineno);
+		ap_php_snprintf(buf, sizeof(buf), "%s - %s (attacker '%s', attacker-request-id '%s', file '%s', line %u)", alertstring, error, ip_address, request_id, fname, lineno);
 	} else {
 		fname = suhosin_getenv("SCRIPT_FILENAME", 15 TSRMLS_CC);
 		if (fname==NULL) {
 			fname = "unknown";
 		}
-		ap_php_snprintf(buf, sizeof(buf), "%s - %s (attacker '%s', file '%s')", alertstring, error, ip_address, fname);
+		ap_php_snprintf(buf, sizeof(buf), "%s - %s (attacker '%s', attacker-request-id '%s', file '%s')", alertstring, error, ip_address, request_id, fname);
 	}
 			
 	/* Syslog-Logging disabled? */

--- a/php_suhosin.h
+++ b/php_suhosin.h
@@ -223,6 +223,7 @@ ZEND_BEGIN_MODULE_GLOBALS(suhosin)
 
 /*	log */
 	zend_bool log_use_x_forwarded_for;
+	zend_bool log_use_x_request_id;
 	long	log_syslog;
 	long	log_syslog_facility;
 	long	log_syslog_priority;

--- a/suhosin.c
+++ b/suhosin.c
@@ -778,6 +778,7 @@ static zend_ini_entry shared_ini_entries[] = {
 	ZEND_INI_ENTRY("suhosin.log.script",			"0",		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateSuhosin_log_script)
 	ZEND_INI_ENTRY("suhosin.log.script.name",			NULL,		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateSuhosin_log_scriptname)
 	STD_ZEND_INI_BOOLEAN("suhosin.log.use-x-forwarded-for",	"0",		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateLogBool, log_use_x_forwarded_for,	zend_suhosin_globals,	suhosin_globals)
+	STD_ZEND_INI_BOOLEAN("suhosin.log.use-x-request-id", "0",   ZEND_INI_PERDIR|ZEND_INI_SYSTEM, OnUpdateLogBool, log_use_x_request_id, zend_suhosin_globals, suhosin_globals)
 	ZEND_INI_ENTRY("suhosin.log.phpscript",			"0",		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateSuhosin_log_phpscript)
 	STD_ZEND_INI_ENTRY("suhosin.log.phpscript.name",			NULL,		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateLogString, log_phpscriptname, zend_suhosin_globals, suhosin_globals)
 	ZEND_INI_ENTRY("suhosin.log.file",			"0",		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateSuhosin_log_file)

--- a/suhosin.ini
+++ b/suhosin.ini
@@ -310,6 +310,20 @@
 ;suhosin.log.use-x-forwarded-for = Off
 ;
 ; 
+; suhosin.log.use-x-request-id
+; ----------------------------
+;
+; * Type: Boolean
+; * Default: Off
+; 
+; When the Suhosin logs an error the log message also contains the Request ID of
+; the attacker. Usually this Request ID is retrieved from the UNIQUE_ID SAPI
+; environment variable. Also X-Request-ID HTTP header can be used if available.
+; With this option enabled you will provided with a better way in order
+; trace Suhosin issues.
+;
+;suhosin.log.use.x-request-id = Off
+; 
 ; ================
 ; Executor Options
 ; ================


### PR DESCRIPTION
As of Nginx 1.11 [$request_id](http://nginx.org/en/docs/http/ngx_http_core_module.html#var_request_id) has been added to it for a better tracing as described in [here](https://www.nginx.com/blog/application-tracing-nginx-plus/) so I decided to add it into suhosin in case anyone uses this nginx feature or using [mod_unique_id](http://httpd.apache.org/docs/current/mod/mod_unique_id.html) which consider the same