### PR TITLE
fix 'LOCK_EX/LOCK_UN' undeclared error on alpine

### DIFF
--- a/log.c
+++ b/log.c
@@ -57,7 +57,7 @@
 #ifdef PHP_WIN32
 static HANDLE log_source = 0;
 #endif
-
+#include <sys/file.h>
 
 static char *loglevel2string(int loglevel)
 {


### PR DESCRIPTION
add sys/file.h to avoid error: 'LOCK_EX/LOCK_UN' undeclared (first use in this function) error on alpine